### PR TITLE
Update S61unbound

### DIFF
--- a/S61unbound
+++ b/S61unbound
@@ -47,4 +47,5 @@ elif [ "$1" = "restart" ]; then
 elif [ "$1" = "stop" ]; then
 . /opt/etc/init.d/rc.func && logger -st "S61unbound" "Stopping Unbound DNS server $0"
 fi
-
+#for any other arguements
+. /opt/etc/init.d/rc.func

--- a/S61unbound
+++ b/S61unbound
@@ -9,21 +9,6 @@ if [ "$1" = "start" ] && [ "$(nvram get ntp_ready)" = "0" ]; then
                 [ "$ntptimer" -eq "1" ] && logger -st "S61unbound" "Waiting for NTP to sync before starting Unbound..."
                 sleep 1
         done
-        if [ "ntptimer" -gt "60" ]; then
-                local NW_STATE
-                local RES_STATE
-                ping 1.1.1.1 -c1 -W2 >/dev/null 2>&1
-                NW_STATE=$?
-                nslookup google.com >/dev/null 2>&1
-                RES_STATE=$?
-                if [ -z "`pidof unbound`" ]; then
-                        logger -st "S61unbound" "Warning: unbound is dead"
-                        /opt/etc/init.d/S61unbound start && exit
-                elif [ $NW_STATE -eq 0 ] && [ $RES_STATE -ne 0 ]; then
-                        logger -st "S61unbound" "Warning: unbound is not responding"
-                        /opt/etc/init.d/S61unbound start && exit
-                fi
-        fi
 fi
 
 # set environment PATH to system binaries

--- a/S61unbound
+++ b/S61unbound
@@ -33,12 +33,10 @@ if [ "$1" = "start" ]; then
                 RES_STATE=$?
                 if [ -z "`pidof unbound`" ]; then
                         logger -st "S61unbound" "Warning: unbound is dead"
-                        /opt/etc/init.d/S61unbound start
-                        break
+                        /opt/etc/init.d/S61unbound restart
                 elif [ $NW_STATE -eq 0 ] && [ $RES_STATE -ne 0 ]; then
                         logger -st "S61unbound" "Warning: unbound is not responding"
-                        /opt/etc/init.d/S61unbound start
-                        break
+                        /opt/etc/init.d/S61unbound restart
                 fi
                 sleep 10
         done

--- a/S61unbound
+++ b/S61unbound
@@ -35,9 +35,11 @@ if [ "$1" = "start" ] || [ "$1" = "restart" ]; then
                 if [ -z "`pidof unbound`" ]; then
                         logger -st "S61unbound" "Warning: unbound is dead"
                         /opt/etc/init.d/S61unbound start
+                        break
                 elif [ $NW_STATE -eq 0 ] && [ $RES_STATE -ne 0 ]; then
                         logger -st "S61unbound" "Warning: unbound is not responding"
                         /opt/etc/init.d/S61unbound start
+                        break
                 fi
                 sleep 10
         done

--- a/S61unbound
+++ b/S61unbound
@@ -44,6 +44,7 @@ elif [ "$1" = "restart" ]; then
 . /opt/etc/init.d/rc.func && logger -st "S61unbound" "Restarting Unbound DNS server $0"
 elif [ "$1" = "stop" ]; then
 . /opt/etc/init.d/rc.func && logger -st "S61unbound" "Stopping Unbound DNS server $0"
+kill -9 $0
 fi
 #for any other arguements
 . /opt/etc/init.d/rc.func

--- a/S61unbound
+++ b/S61unbound
@@ -1,21 +1,5 @@
 #!/bin/sh
 
-if [ "$1" = "start" ] || [ "$1" = "restart" ]; then
-        # Wait for NTP before starting
-        ntptimer=0
-        while [ "$(nvram get ntp_ready)" = "0" ] && [ "$ntptimer" -lt "60" ]; do
-                ntptimer=$((ntptimer+1))
-                [ "$ntptimer" -eq "1" ] && logger -st "S61unbound" "Waiting for NTP to sync before starting Unbound..."
-                sleep 1
-        done
-
-        if [ "$ntptimer" -ge "60" ]; then
-                logger -st "S61unbound" "NTP failed to sync after 1 minute - please check immediately!"
-                exit 1
-        fi
-fi
-
-logger -t S61unbound "Starting Unbound DNS server $0"
 # set environment PATH to system binaries
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin:$PATH
 export TZ=$(cat /etc/TZ)
@@ -28,4 +12,34 @@ POSTCMD="service restart_dnsmasq"
 DESC=$PROCS
 PATH=/opt/sbin:/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-. /opt/etc/init.d/rc.func
+if [ "$1" = "start" ] || [ "$1" = "restart" ]; then
+        # Wait for NTP before starting
+        ntptimer=0
+        while [ "$(nvram get ntp_ready)" = "0" ] || [ "$ntptimer" -lt "5" ]; do
+                ntptimer=$((ntptimer+1))
+                [ "$ntptimer" -eq "1" ] && logger -st "S61unbound" "Starting Unbound Monitor."
+                
+                sleep 1
+        done
+        
+        . /opt/etc/init.d/rc.func && logger -st "S61unbound" "Starting Unbound DNS server $0"
+        
+        while [ "$ntptimer" -ge "5" ]; do
+                local NW_STATE
+                local RES_STATE
+                local COUNT=0
+                ping 1.1.1.1 -c1 -W2 >/dev/null 2>&1
+                NW_STATE=$?
+                nslookup google.com >/dev/null 2>&1
+                RES_STATE=$?
+                if [ -z "`pidof unbound`" ]; then
+                        logger -st "S61unbound" "Warning: unbound is dead"
+                        /opt/etc/init.d/S61unbound start
+                elif [ $NW_STATE -eq 0 ] && [ $RES_STATE -ne 0 ]; then
+                        logger -st "S61unbound" "Warning: unbound is not responding"
+                        /opt/etc/init.d/S61unbound start
+                fi
+                sleep 10
+        done
+fi
+

--- a/S61unbound
+++ b/S61unbound
@@ -10,6 +10,7 @@ if [ "$1" = "start" ] && [ "$(nvram get ntp_ready)" = "0" ]; then
         done
 fi
 
+logger -t S61unbound "Starting Unbound DNS server $0"
 # set environment PATH to system binaries
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin:$PATH
 export TZ=$(cat /etc/TZ)

--- a/S61unbound
+++ b/S61unbound
@@ -1,5 +1,31 @@
 #!/bin/sh
 
+
+if [ "$1" = "start" ] && [ "$(nvram get ntp_ready)" = "0" ]; then
+        # Wait for NTP before starting
+        ntptimer=0
+        while [ "$ntptimer" -lt "60" ]; do
+                ntptimer=$((ntptimer+1))
+                [ "$ntptimer" -eq "1" ] && logger -st "S61unbound" "Waiting for NTP to sync before starting Unbound..."
+                sleep 1
+        done
+        if [ "ntptimer" -gt "60" ]; then
+                local NW_STATE
+                local RES_STATE
+                ping 1.1.1.1 -c1 -W2 >/dev/null 2>&1
+                NW_STATE=$?
+                nslookup google.com >/dev/null 2>&1
+                RES_STATE=$?
+                if [ -z "`pidof unbound`" ]; then
+                        logger -st "S61unbound" "Warning: unbound is dead"
+                        /opt/etc/init.d/S61unbound start && exit
+                elif [ $NW_STATE -eq 0 ] && [ $RES_STATE -ne 0 ]; then
+                        logger -st "S61unbound" "Warning: unbound is not responding"
+                        /opt/etc/init.d/S61unbound start && exit
+                fi
+        fi
+fi
+
 # set environment PATH to system binaries
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin:$PATH
 export TZ=$(cat /etc/TZ)
@@ -12,39 +38,4 @@ POSTCMD="service restart_dnsmasq"
 DESC=$PROCS
 PATH=/opt/sbin:/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-if [ "$1" = "start" ]; then
-        # Wait for NTP before starting
-        ntptimer=0
-        while [ "$(nvram get ntp_ready)" = "0" ] || [ "$ntptimer" -lt "5" ]; do
-                ntptimer=$((ntptimer+1))
-                [ "$ntptimer" -eq "1" ] && logger -st "S61unbound" "Starting Unbound Monitor."
-                
-                sleep 1
-        done
-        
-        . /opt/etc/init.d/rc.func && logger -st "S61unbound" "Starting Unbound DNS server $0"
-        
-        while [ "$ntptimer" -ge "5" ]; do
-                local NW_STATE
-                local RES_STATE
-                ping 1.1.1.1 -c1 -W2 >/dev/null 2>&1
-                NW_STATE=$?
-                nslookup google.com >/dev/null 2>&1
-                RES_STATE=$?
-                if [ -z "`pidof unbound`" ]; then
-                        logger -st "S61unbound" "Warning: unbound is dead"
-                        /opt/etc/init.d/S61unbound restart
-                elif [ $NW_STATE -eq 0 ] && [ $RES_STATE -ne 0 ]; then
-                        logger -st "S61unbound" "Warning: unbound is not responding"
-                        /opt/etc/init.d/S61unbound restart
-                fi
-                sleep 10
-        done
-elif [ "$1" = "restart" ]; then
-. /opt/etc/init.d/rc.func && logger -st "S61unbound" "Restarting Unbound DNS server $0"
-elif [ "$1" = "stop" ]; then
-. /opt/etc/init.d/rc.func && logger -st "S61unbound" "Stopping Unbound DNS server $0"
-kill -9 $0
-fi
-#for any other arguements
 . /opt/etc/init.d/rc.func

--- a/S61unbound
+++ b/S61unbound
@@ -12,7 +12,7 @@ POSTCMD="service restart_dnsmasq"
 DESC=$PROCS
 PATH=/opt/sbin:/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-if [ "$1" = "start" ] || [ "$1" = "restart" ]; then
+if [ "$1" = "start" ]; then
         # Wait for NTP before starting
         ntptimer=0
         while [ "$(nvram get ntp_ready)" = "0" ] || [ "$ntptimer" -lt "5" ]; do
@@ -42,5 +42,9 @@ if [ "$1" = "start" ] || [ "$1" = "restart" ]; then
                 fi
                 sleep 10
         done
+elif [ "$1" = "restart" ]; then
+. /opt/etc/init.d/rc.func && logger -st "S61unbound" "Restarting Unbound DNS server $0"
+elif [ "$1" = "stop" ]; then
+. /opt/etc/init.d/rc.func && logger -st "S61unbound" "Stopping Unbound DNS server $0"
 fi
 

--- a/S61unbound
+++ b/S61unbound
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-
 if [ "$1" = "start" ] && [ "$(nvram get ntp_ready)" = "0" ]; then
         # Wait for NTP before starting
         ntptimer=0

--- a/S61unbound
+++ b/S61unbound
@@ -27,7 +27,6 @@ if [ "$1" = "start" ] || [ "$1" = "restart" ]; then
         while [ "$ntptimer" -ge "5" ]; do
                 local NW_STATE
                 local RES_STATE
-                local COUNT=0
                 ping 1.1.1.1 -c1 -W2 >/dev/null 2>&1
                 NW_STATE=$?
                 nslookup google.com >/dev/null 2>&1


### PR DESCRIPTION
This will provide users with a better Unbound functionality there was many times during testing that the current function being used prevented DNS service from starting simply because the clock didn't set right on the router. This is problematic because sometimes under certain circumstances (wan events and what have you) , the clock may not set right or the ntp ram variables may not work properly. that shouldn't prevent dns service from starting. 