### PR TITLE
Added site list to easily edit hosts, domains, and whitelist-domains

### DIFF
--- a/adblock/gen_adblock.sh
+++ b/adblock/gen_adblock.sh
@@ -16,7 +16,7 @@ echo "Removing possible temporary files.."
 
 # check for sites file
 if [ ! -f $sites ]; then
-  echo "Missing $sites file"
+  logger -st "($(basename $0))" "Missing $sites file"
   exit
 fi
 
@@ -56,12 +56,12 @@ awk 'NR==FNR{a[$0];next} !($0 in a) {print $NF}' $permlist $tempoutlist > $outli
 
 echo "Removing duplicate formatting from the domain list..."
 cat $outlist | sed -r -e 's/[[:space:]]+/\t/g' | sed -e 's/\t*#.*$//g' | sed -e 's/[^a-zA-Z0-9\.\_\t\-]//g' | sed -e 's/\t$//g' | sed -e '/^#/d' | sort -u | sed '/^$/d' | awk -v "IP=$destinationIP" '{sub(/\r$/,""); print IP" "$0}' > $finalist
-numberOfAdsBlocked=$(cat $outlist | wc -l | sed 's/^[ \t]*//')
+numberOfAdsBlocked=$(wc -l < $outlist)
 echo "$numberOfAdsBlocked domains compiled"
 
 echo "Generating Unbound adlist....."
-cat $finalist | grep '^0\.0\.0\.0' | awk '{print "local-zone: \""$2"\" always_nxdomain"}' > $adlist
-numberOfAdsBlocked=$(cat $adlist | wc -l | sed 's/^[ \t]*//')
+awk '/^0.0.0.0/ {print "local-zone: \""$2"\" always_nxdomain"}' $finalist > $adlist
+numberOfAdsBlocked=$(wc -l < $adlist)
 echo "$numberOfAdsBlocked suspicious and blocked domains"
 
 echo "Removing temporary files..."

--- a/adblock/gen_adblock.sh
+++ b/adblock/gen_adblock.sh
@@ -55,7 +55,7 @@ echo "Edit User Custon list of allowed domains..."
 awk 'NR==FNR{a[$0];next} !($0 in a) {print $NF}' $permlist $tempoutlist > $outlist
 
 echo "Removing duplicate formatting from the domain list..."
-cat $outlist | sed -r -e 's/[[:space:]]+/\t/g' | sed -e 's/\t*#.*$//g' | sed -e 's/[^a-zA-Z0-9\.\_\t\-]//g' | sed -e 's/\t$//g' | sed -e '/^#/d' | sort -u | sed '/^$/d' | awk -v "IP=$destinationIP" '{sub(/\r$/,""); print IP" "$0}' > $finalist
+cat $outlist | sed -r -e 's/[[:space:]]+/\t/g' | sed -e 's/\t*#.*$//g' | sed -e 's/[^a-zA-Z0-9\.\_\t\-]//g' | sed -e 's/\t$//g' | sed -e '/^#/d' | sed -e '/^\([0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\).*$/d' | sed -e 's/^[ \t]*//;s/[ \t]*$//' | sort -u | sed '/^$/d' | awk -v "IP=$destinationIP" '{sub(/\r$/,""); print IP" "$0}' > $finalist
 numberOfAdsBlocked=$(wc -l < $outlist)
 echo "$numberOfAdsBlocked domains compiled"
 

--- a/adblock/gen_adblock.sh
+++ b/adblock/gen_adblock.sh
@@ -1,24 +1,46 @@
 #!/bin/bash
 destinationIP="0.0.0.0"
 tempoutlist="/opt/var/lib/unbound/adblock/adlist.tmp"
+tempwhitelistoutlist="/opt/var/lib/unbound/adblock/whitelist.tmp"
 outlist='/opt/var/lib/unbound/adblock/tmp.host'
 finalist='/opt/var/lib/unbound/adblock/tmp.finalhost'
 permlist='/opt/var/lib/unbound/adblock/permlist'
 adlist='/opt/var/lib/unbound/adblock/adservers'
+sites='/opt/var/lib/unbound/adblock/sites'
 
 echo "Removing possible temporary files.."
 [ -f $tempoutlist ] && rm -f $tempoutlist
+[ -f $tempwhitelistoutlist ] && rm -f $tempwhitelistoutlist
 [ -f $outlist ] && rm -f $outlist
 [ -f $finalist ] && rm -f $finalist
 
-echo "Dowloading StevenBlack Adlist..."
-curl --progress-bar https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts | grep -v "#" | grep -v "::1" | grep -v "0.0.0.0 0.0.0.0" | sed '/^$/d' | sed 's/\ /\\ /g' | awk '{print $2}' | grep -v '^\\' | grep -v '\\$'| sort >> $tempoutlist
-echo "Dowloading Domains wildcard Adlist..."
-curl --progress-bar https://raw.githubusercontent.com/dnswarden/blocklist/master/blacklist-full.txt >> $tempoutlist
+# check for sites file
+if [ ! -f $sites ]; then
+  echo "Missing $sites file"
+  exit
+fi
 
-# Requires available memory. Use with care.
-# echo "Dowloading firstparty trackers Adlist..."
-# curl --progress-bar https://hostfiles.frogeye.fr/firstparty-trackers-hosts.txt | grep -v "#" | grep -v "::1" | grep -v "0.0.0.0 0.0.0.0" | sed '/^$/d' | sed 's/\ /\\ /g' | awk '{print $2}' | grep -v '^\\' | grep -v '\\$'| sort >> $tempoutlist
+# process sites list
+while read -r line
+do
+  set -- $line
+  if [ "$2" != "" ]; then
+    if [ "$1" == "hosts" ]; then
+      echo "Processsing hosts file @ $2"
+      curl --progress-bar $2 | grep -v "#" | grep -v "::1" | grep -v "0.0.0.0 0.0.0.0" | sed '/^$/d' | sed 's/\ /\\ /g' | awk '{print $2}' | grep -v '^\\' | grep -v '\\$'| sort >> $tempoutlist
+    elif [ "$1" == "domains" ]; then
+     echo "Processing domains file @ $2"
+     curl --progress-bar $2 >> $tempoutlist
+    elif [ "$1" == "whitelist-domains" ]; then
+     echo "Processing whitelist domains file @ $2"
+     curl --progress-bar $2 >> $tempwhitelistoutlist
+    else
+      echo "Unknown file type = $1"
+    fi
+  else
+    echo "Missing site URL on line $line"
+  fi
+done < "$sites"
 
 echo "Combining User Custom block host..."
 cat /opt/var/lib/unbound/adblock/blockhost >> $tempoutlist
@@ -27,6 +49,12 @@ echo "Removing duplicate formatting from the domain list..."
 cat $tempoutlist | sed -r -e 's/[[:space:]]+/\t/g' | sed -e 's/\t*#.*$//g' | sed -e 's/[^a-zA-Z0-9\.\_\t\-]//g' | sed -e 's/\t$//g' | sed -e '/^#/d' | sort -u | sed '/^$/d' | awk -v "IP=$destinationIP" '{sub(/\r$/,""); print IP" "$0}' > $outlist
 numberOfAdsBlocked=$(cat $outlist | wc -l | sed 's/^[ \t]*//')
 echo "$numberOfAdsBlocked domains compiled"
+
+if [ -f $tempwhitelistoutlist ]; then
+  echo "Removing any downloaded whitelist items..."
+  fgrep -vf $tempwhitelistoutlist $outlist > $finalist
+  mv $finalist $outlist
+fi
 
 echo "Edit User Custon list of allowed domains..."
 fgrep -vf $permlist $outlist  > $finalist
@@ -38,10 +66,11 @@ echo "$numberOfAdsBlocked suspicious and blocked domains"
 
 echo "Removing temporary files..."
 [ -f $tempoutlist ] && rm -f $tempoutlist
+[ -f $tempwhitelistoutlist ] && rm -f $tempwhitelistoutlist
 [ -f $outlist ] && rm -f $outlist
 [ -f $finalist ] && rm -f $finalist
 
-echo "Removing log's files..."
-[ -f /opt/var/lib/unbound/unbound.log ] && rm -f /opt/var/lib/unbound/unbound.log
+#echo "Removing log's files..."
+#[ -f /opt/var/lib/unbound/unbound.log ] && rm -f /opt/var/lib/unbound/unbound.log
 echo "Restarting DNS servers..."
 /opt/etc/init.d/S61unbound restart

--- a/adblock/permlist
+++ b/adblock/permlist
@@ -1,3 +1,13 @@
+asuswrt-merlin.net
+asuswrt.lostrealm.ca
+bin.entware.net
+codeload.github.com
+fwupdate.asuswrt-merlin.net
+pkg.entware-backports.tk
+pkg.entware.net
+raw.githubusercontent.com
+sourceforge.net
+www.asuswrt-merlin.net
 ipinfo.io
 aax-eu.amazon-adsystem.com 
 aax-us-east.amazon-adsystem.com 

--- a/adblock/sites
+++ b/adblock/sites
@@ -1,0 +1,3 @@
+hosts https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
+domains https://raw.githubusercontent.com/mitchellkrogza/The-Big-List-of-Hacked-Malware-Web-Sites/master/hacked-domains.list
+whitelist-domains https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt

--- a/adblock/sites
+++ b/adblock/sites
@@ -1,3 +1,1 @@
 hosts https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
-domains https://raw.githubusercontent.com/mitchellkrogza/The-Big-List-of-Hacked-Malware-Web-Sites/master/hacked-domains.list
-whitelist-domains https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt


### PR DESCRIPTION
Updated script to not be hard coded with fixed lists, but now you can edit a new file called "sites" which can handle 3 file types.

The file is of the format:
<type> <URL>
<type> <URL>
...

1. hosts -> These are host type files, and the processing is done to prepare them for merge.
2. domains -> These are lists of domains to block, they are simply appended.
3. whitelist-domains -> These are lists of domains to whitelist (remove) from the merged ad-block list.

I also added some protection for Asus  Merlin and entware URL from accidently being blocked.